### PR TITLE
DB Error when adding video source

### DIFF
--- a/mythtv/libs/libmythtv/sourceutil.cpp
+++ b/mythtv/libs/libmythtv/sourceutil.cpp
@@ -485,7 +485,7 @@ int SourceUtil::CreateSource( const QString& sourcename,
                   "lcnoffset) "
                   "VALUES (:NAME, :XMLTVGRABBER, :USERID, :FREQTABLE, :LINEUPID, :PASSWORD, "
                   ":USEEIT, :CONFIGPATH, :NITID, :BOUQUETID, :REGIONID, :SCANFREQUENCY, "
-                  ":LCNOFFSET");
+                  ":LCNOFFSET)");
 
     query.bindValue(":NAME", sourcename);
     query.bindValue(":XMLTVGRABBER", grabber);


### PR DESCRIPTION
After 8a9427b if one tries to create a new videosource via the services API one may receive an error.
It would appear there is a missing ")" in the constructed SQL.

Fixes #358

Signed-off-by: Klaas de Waal <kdewaal@mythtv.org>

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

